### PR TITLE
Improve pkg.json & tsconfig.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # react-testing-kit
 
-[![Actions Status](https://github.com/mAAdhaTTah/react-testing-kit/workflows/Run tests/badge.svg)](https://github.com/mAAdhaTTah/react-testing-kit/actions)
-
+[![Actions Status](https://github.com/mAAdhaTTah/react-testing-kit/workflows/Run%20tests/badge.svg)](https://github.com/mAAdhaTTah/react-testing-kit/actions)
 
 A testing library to enable reusable, readable logic in your unit tests.
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "types": "dist/react-testing-kit.d.ts",
   "scripts": {
     "dev": "microbundle watch",
-    "build": "rimraf dist && microbundle",
+    "build": "rimraf dist && microbundle --no-compress --external react,@testing-library/react",
     "format": "prettier --write *.ts*",
     "test": "npm run test:format && npm run test:unit",
     "test:format": "prettier --check *.ts*",
@@ -25,6 +25,10 @@
   "homepage": "https://github.com/mAAdhaTTah/react-testing-kit",
   "repository": "github:mAAdhaTTah/react-testing-kit",
   "license": "ISC",
+  "peerDependencies": {
+    "@testing-library/react": "^8 || ^9 || ^10",
+    "react": "^16.0.0"
+  },
   "devDependencies": {
     "@testing-library/react": "^9.3.0",
     "@types/jest": "^24.0.19",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "target": "es5",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",


### PR DESCRIPTION
For tsconfig.json, we have a duplicate key we don't need twice.
For package.json, ensure `react` & `@testing-library/react`
 is an external & disable compression on the build. Since this is
in node, it's not necessary to compress.

Lastly, add the relevant dependencies as peer dependencies and
fix the badge on the README.