### PR TITLE
Allow `defaultProps` to be a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This encourages a test API that's consistent, making complex tests more readable
 
 Create a render function for use in a test. `config` takes these properties:
 
-* `defaultProps`: The properties the component should be rendered with by default.
+* `defaultProps`: The properties the component should be rendered with by default. Can also be provided as a function which will be called on each render.
 * `component`: The component to test.
 * `render`: The render function to create an instance.
 * `elements`: Function to create the component elements.

--- a/react-testing-kit.spec.tsx
+++ b/react-testing-kit.spec.tsx
@@ -79,3 +79,28 @@ test('it returns the async waits', async () => {
 
   await expect(waitForRemoved).resolves.toEqual(true);
 });
+
+it('accepts a function for props', () => {
+  const renderComponent = createRender({
+    // @TODO(mAAdhaTTah) why cast to any?
+    defaultProps: () => ({ text: 'hello', onClick: jest.fn() as any }),
+    component: TestComponent,
+    render,
+    elements: (queries: RenderResult) => ({
+      button: () => queries.getByTestId('button') as HTMLButtonElement,
+      icon: () => queries.getByTestId('icon') as HTMLSpanElement,
+    }),
+    fire: elements => ({
+      buttonClick: () => fireEvent.click(elements.button()),
+    }),
+    waitFor: elements => ({
+      icon: () => waitForElement(elements.icon),
+      iconToBeRemoved: () => waitForElementToBeRemoved(elements.icon),
+    }),
+  });
+
+  const first = renderComponent();
+  const second = renderComponent();
+
+  expect(first.props).not.toBe(second.props);
+});

--- a/react-testing-kit.ts
+++ b/react-testing-kit.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import { RenderResult } from '@testing-library/react';
 
 interface RenderConfig<P, E, F, A> {
-  defaultProps: P;
+  defaultProps: P | (() => P);
   component: React.ComponentType<P>;
   render: (ui: React.ReactElement<P>) => RenderResult;
   elements: (queries: RenderResult) => E;
@@ -33,7 +33,13 @@ export const createRender = <P, E, F, A>({
 }: RenderConfig<P, E, F, A>) => (
   overrides: Partial<P> = {},
 ): RenderInstance<P, E, F, A> => {
-  const props: P = { ...defaultProps, ...overrides };
+  const props: P = {
+    // @TODO(mAAdhaTTaah) remove cast?
+    ...(typeof defaultProps === 'function'
+      ? (defaultProps as any)()
+      : defaultProps),
+    ...overrides,
+  };
   const queries = render(React.createElement(component, props));
   const elements = getElements(queries);
   const fire = getEvents(elements);


### PR DESCRIPTION
This allows users to ensure new props are provided on each render
so things like mock functions aren't reused between renders/