### PR TITLE
Make fire & waitFor optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12817,9 +12817,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:format && npm run test:unit",
     "test:format": "prettier --check *.ts*",
     "test:unit": "jest --coverage",
-    "prepublish": "npm test && npm run build"
+    "prepublishOnly": "npm test && npm run build"
   },
   "files": [
     "dist",
@@ -40,6 +40,6 @@
     "react-dom": "^16.10.2",
     "rimraf": "^3.0.0",
     "ts-jest": "^25.0.0",
-    "typescript": "^3.6.4"
+    "typescript": "^3.8.0"
   }
 }

--- a/react-testing-kit.spec.tsx
+++ b/react-testing-kit.spec.tsx
@@ -80,7 +80,7 @@ test('it returns the async waits', async () => {
   await expect(waitForRemoved).resolves.toEqual(true);
 });
 
-it('accepts a function for props', () => {
+test('it accepts a function for props', () => {
   const renderComponent = createRender({
     // @TODO(mAAdhaTTah) why cast to any?
     defaultProps: () => ({ text: 'hello', onClick: jest.fn() as any }),
@@ -103,4 +103,21 @@ it('accepts a function for props', () => {
   const second = renderComponent();
 
   expect(first.props).not.toBe(second.props);
+});
+
+test('fire and waitFor are optional', () => {
+  const renderComponent = createRender({
+    defaultProps: { text: 'hello', onClick: jest.fn() },
+    component: TestComponent,
+    render,
+    // @TODO(mAAdhaTTah) required to get inference working - why?
+    elements: (queries: RenderResult) => ({
+      button: () => queries.getByTestId('button') as HTMLButtonElement,
+      icon: () => queries.getByTestId('icon') as HTMLSpanElement,
+    }),
+  });
+
+  const instance = renderComponent();
+
+  expect(instance.container.textContent).toEqual('hello');
 });

--- a/react-testing-kit.ts
+++ b/react-testing-kit.ts
@@ -6,11 +6,11 @@ interface RenderConfig<P, E, F, A> {
   component: React.ComponentType<P>;
   render: (ui: React.ReactElement<P>) => RenderResult;
   elements: (queries: RenderResult) => E;
-  fire: (elements: E) => F;
-  waitFor: (elements: E) => A;
+  fire?: (elements: E) => F;
+  waitFor?: (elements: E) => A;
 }
 
-interface RenderInstance<P, E, F, A> {
+interface RenderInstance<P, E, F = {}, A = {}> {
   props: P;
   container: RenderResult['container'];
   baseElement: RenderResult['baseElement'];
@@ -42,8 +42,8 @@ export const createRender = <P, E, F, A>({
   };
   const queries = render(React.createElement(component, props));
   const elements = getElements(queries);
-  const fire = getEvents(elements);
-  const waitFor = getAsync(elements);
+  const fire = getEvents != null ? getEvents(elements) : ({} as F);
+  const waitFor = getAsync != null ? getAsync(elements) : ({} as A);
 
   const {
     container,


### PR DESCRIPTION
These aren't strictly required, because you may only need element
querying. `elements` is still required because otherwise, what's
the point of the kit?