### PR TITLE
Fix esm bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "source": "react-testing-kit.ts",
   "main": "dist/react-testing-kit.js",
   "unpkg": "dist/react-testing-kit.umd.js",
-  "module": "dist/react-testing-kit.mjs",
+  "module": "dist/react-testing-kit.esm.js",
   "types": "dist/react-testing-kit.d.ts",
   "scripts": {
     "dev": "microbundle watch",


### PR DESCRIPTION
Don't use `.mjs` extension because the output isn't `.mjs` compatible.